### PR TITLE
W on gpu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ INTERPOLATION_FUNC=P8R2
 
 all:
 	cd src && $(MAKE)
-	cd src/interpolation && $(MAKE) CXX=g++
+	cd src/interpolation && $(MAKE)
 	mkdir -p lib
 	$(MPICXX) -shared  $(OBJS) -o lib/lib$(LNAME).so
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 export
 
 CXXFLAGS+= -std=c++14 -O3 -mavx2  -march=native   
-MPICXX=mpic++
+MPICXX=mpic++ 
 
 
 
 
 ifeq ($(BUILD),GPU)
-  CXX=nvcc -x cu --expt-relaxed-constexpr --expt-extended-lambda --gpu-architecture=compute_70 --gpu-code=sm_70,compute_70
+  CXX=nvcc -dc -x cu -std=c++14 -maxrregcount=255 --ptxas-options=-O3 --use_fast_math --expt-relaxed-constexpr --expt-extended-lambda --gpu-architecture=compute_70 --gpu-code=sm_70,compute_70
   NVE="
   NVB=--compiler-options="
 else
@@ -20,13 +20,13 @@ LNAME=strugepic
 SRCS := $(wildcard src/*.cpp src/interpolation/*.cpp )
 OBJS := $(patsubst %.cpp,%.o,$(SRCS))
 
-INTERPOLATION_FUNC=P8R2
+INTERPOLATION_FUNC=PWL
 
 all:
 	cd src && $(MAKE)
 	cd src/interpolation && $(MAKE)
 	mkdir -p lib
-	$(MPICXX) -shared  $(OBJS) -o lib/lib$(LNAME).so
+	nvcc --gpu-architecture=compute_70 --gpu-code=sm_70,compute_70 -lib $(OBJS) -o lib/lib$(LNAME).a
 
 install:
 	mkdir $(PREFIX)/lib

--- a/include/strugepic_w.hpp
+++ b/include/strugepic_w.hpp
@@ -2,15 +2,16 @@
 #define WDEFS
 
 #include <AMReX_REAL.H>
-
+#include <AMReX_GpuQualifiers.H>
 
 // Interface to the interpolation functions used by the alogrithm
 // How and where they are implement is up to the user (Just link against a compiled object file or dynamic library )
 
-amrex::Real W1(amrex::Real x);
-amrex::Real Wp(amrex::Real x);
-amrex::Real I_W1(amrex::Real a,amrex::Real b);
-amrex::Real I_Wp(amrex::Real a,amrex::Real b);
+
+AMREX_GPU_HOST_DEVICE amrex::Real W1(amrex::Real x);
+AMREX_GPU_HOST_DEVICE amrex::Real Wp(amrex::Real x);
+AMREX_GPU_HOST_DEVICE amrex::Real I_W1(amrex::Real a,amrex::Real b);
+AMREX_GPU_HOST_DEVICE amrex::Real I_Wp(amrex::Real a,amrex::Real b);
 extern const int interpolation_range;
 
 

--- a/include/strugepic_w.hpp
+++ b/include/strugepic_w.hpp
@@ -8,6 +8,7 @@
 // How and where they are implement is up to the user (Just link against a compiled object file or dynamic library )
 
 
+
 AMREX_GPU_HOST_DEVICE amrex::Real W1(amrex::Real x);
 AMREX_GPU_HOST_DEVICE amrex::Real Wp(amrex::Real x);
 AMREX_GPU_HOST_DEVICE amrex::Real I_W1(amrex::Real a,amrex::Real b);

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,12 @@
 SRCS    := $(wildcard *.cpp)
 OBJS    := $(patsubst %.cpp,%.o,$(SRCS))
-CXXFLAGS+=-fPIC
 
-all: $(OBJS)
+#CXXFLAGS+=-fPIC
+
+all: $(DOBJS) $(OBJS)
 
 %.o: %.cpp
-	$(CXX) $(NVB)  $(CXXFLAGS) $(NVE) -I ../include $< -o $@ -c 
+	$(CXX) $(NVB)  $(CXXFLAGS) $(NVE) -I ../include $< -o $@  
 
 .PHONY: clean
 clean:

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,12 +1,11 @@
 SRCS    := $(wildcard *.cpp)
 OBJS    := $(patsubst %.cpp,%.o,$(SRCS))
 
-#CXXFLAGS+=-fPIC
 
-all: $(DOBJS) $(OBJS)
+all:  $(OBJS)
 
 %.o: %.cpp
-	$(CXX) $(NVB)  $(CXXFLAGS) $(NVE) -I ../include $< -o $@  
+	$(CXX) $(CXXFLAGS) -I ../include $< -o $@  
 
 .PHONY: clean
 clean:

--- a/src/interpolation/Makefile
+++ b/src/interpolation/Makefile
@@ -10,10 +10,14 @@ ifeq ($(INTERPOLATION_FUNC),PWL)
 CXXFLAGS+=-DINTERPOLATION_PWL=1
 endif
 
+ifeq ($(BUILD),GPU)
+CXXFLAGS+=-DGPUBUILD
+endif
+
 all: $(OBJS)
 
 %.o:  %.cpp $(HDS)
-	$(CXX) -fPIC $(CXXFLAGS)  $< -o $@ -c
+	$(CXX) $(NVB) -fPIC $(CXXFLAGS) $(NVE)  $< -o $@ -c
 
 .PHONY: clean
 clean:

--- a/src/interpolation/Makefile
+++ b/src/interpolation/Makefile
@@ -17,7 +17,7 @@ endif
 all: $(DOBJS) $(OBJS)
 
 %.o:  %.cpp $(HDS)
-	$(CXX) $(NVB) $(CXXFLAGS) $(NVE)  $< -o $@ 
+	$(CXX) $(CXXFLAGS) $< -o $@ 
 
 .PHONY: clean
 clean:

--- a/src/interpolation/Makefile
+++ b/src/interpolation/Makefile
@@ -14,10 +14,10 @@ ifeq ($(BUILD),GPU)
 CXXFLAGS+=-DGPUBUILD
 endif
 
-all: $(OBJS)
+all: $(DOBJS) $(OBJS)
 
 %.o:  %.cpp $(HDS)
-	$(CXX) $(NVB) -fPIC $(CXXFLAGS) $(NVE)  $< -o $@ -c
+	$(CXX) $(NVB) $(CXXFLAGS) $(NVE)  $< -o $@ 
 
 .PHONY: clean
 clean:

--- a/src/interpolation/interpolation.cpp
+++ b/src/interpolation/interpolation.cpp
@@ -7,11 +7,11 @@
 
 #ifdef GPUBUILD
     #define ARRAY_QUALIFIER __device__ __const__ REAL
-    #define FUNC_QUALIFIER  __host__ __device__ REAL  
+    #define FUNC_QUALIFIER  __host__ __device__  REAL __attribute__((weak))   
     #define INT_FUNC_QUALIFIER __host__ __device__ inline REAL  
 #else
     #define ARRAY_QUALIFIER const REAL
-    #define FUNC_QUALIFIER REAL  
+    #define FUNC_QUALIFIER REAL __attribute__((weak))  
     #define INT_FUNC_QUALIFIER inline REAL  
 #endif
 

--- a/src/interpolation/interpolation.cpp
+++ b/src/interpolation/interpolation.cpp
@@ -2,17 +2,25 @@
 #include"poly_util.hpp"
 
 #ifndef REAL
-#define REAL double
+    #define REAL double
 #endif
 
-
+#ifdef GPUBUILD
+    #define ARRAY_QUALIFIER __device__ __const__ REAL
+    #define FUNC_QUALIFIER __device__ REAL __attribute__((weak)) 
+    #define INT_FUNC_QUALIFIER __device__ inline REAL  
+#else
+    #define ARRAY_QUALIFIER const REAL
+    #define FUNC_QUALIFIER REAL __attribute__((weak)) 
+    #define INT_FUNC_QUALIFIER inline REAL  
+#endif
 
 
 #ifdef INTERPOLATION_P8R2
 extern const int __attribute__((weak)) interpolation_range=2;
 // 8th order piecewise polynominal coefficients, from highest to lowest, comments indicate the range
 // Function is zero outside the range
-constexpr  REAL P8_coeffs[36]={
+ARRAY_QUALIFIER P8_coeffs[36]={
         15.0/1024,15.0/128,49.0/128,21.0/32,35.0/64,0,0,1,1,  // -2 -> -1
         -15.0/1024,15.0/128,7.0/16,21.0/32,175.0/256,0,-105.0/128,0,337.0/512, // -1 -> 0
         -15.0/1024,-15.0/128,7.0/16,-21.0/32,175.0/256,0,-105.0/128,0,337.0/512, // 0 -> 1
@@ -21,7 +29,7 @@ constexpr  REAL P8_coeffs[36]={
 
 
 // Derivative for previous
-constexpr  REAL P8d_coeffs[32]={
+ARRAY_QUALIFIER P8d_coeffs[32]={
          15.0/128, 105.0/128, 147.0/64,105.0/32,35.0/16,0,0,1, // -2 -> -1 
          -15.0/128,105.0/128,21.0/8,105.0/32,175.0/64,0,-105.0/64,0,  // -1 -> 0
          -15.0/128,-105.0/128,21.0/8,-105.0/32,175.0/64,0,-105.0/64,0,  // 0  -> 1
@@ -29,12 +37,12 @@ constexpr  REAL P8d_coeffs[32]={
          };
 
 
-constexpr REAL P8_agregate_coeffs[27]={
+ARRAY_QUALIFIER P8_agregate_coeffs[27]={
         15.0/1024,0,-28.0/1024,0,-70.0/1024,0,420.0/1024,512.0/1024,175.0/1024, //-1->0
         0,120.0/1024,-420.0/1024,672.0/1024,-630.0/1024,0,420.0/1024,512.0/1024,175.0/1024, // 0->1
         -15.0/1024,120.0/1024,-392.0/1024,672.0/1024,-560.0/1024,0,0,1024.0/1024,0 // 1->2                                  
 };
-constexpr REAL P8d_agregate_coeffs[24]={
+ARRAY_QUALIFIER P8d_agregate_coeffs[24]={
         15.0/128,0,-21.0/128,0 ,-35.0/128,0,105.0/128,64.0/128, // -1 -> 0
         0,105.0/128, -315.0/128, 420.0/128, -315.0/128,0, 105.0/128,64.0/128, // 0->1
         -15.0/128, 105.0/128, -147.0/64,+105.0/32 ,-35.0/16,0,0,+1 // 1-2
@@ -42,7 +50,7 @@ constexpr REAL P8d_agregate_coeffs[24]={
 
 
 // Integral coefficients (with extra constant so continuous)
-constexpr  REAL P8I_coeffs[40]={
+ARRAY_QUALIFIER P8I_coeffs[40]={
         5.0/3072,15.0/1024,7.0/128,7.0/64,7.0/64,0,0,1.0/2,1,7.0/12, // -2 -> 1
         -5./3072,15./1024,1./16,7./64,35./256,0,-35./128,0,337./512,1.0/2 , // -1->0
         -5./3072,-15./1024,1./16,-7./64,35./256,0,-35./128,0,337./512,1.0/2 , // 0->1
@@ -50,27 +58,27 @@ constexpr  REAL P8I_coeffs[40]={
         };
 
 
-REAL __attribute__((weak)) W1(REAL x){
+FUNC_QUALIFIER W1(REAL x){
     return P<REAL,8,-2,2>(x,P8_coeffs); 
 }
 
-REAL __attribute__((weak)) W(REAL x,REAL y, REAL z){
+FUNC_QUALIFIER W(REAL x,REAL y, REAL z){
     return W1(x)*W1(y)*W1(z);
 }
 
-REAL __attribute__((weak)) W1d(REAL x){
+FUNC_QUALIFIER W1d(REAL x){
     return P<REAL,7,-2,2>(x,P8d_coeffs);
 }
 
-REAL __attribute__((weak)) I_W1(REAL a,REAL b ){
+FUNC_QUALIFIER I_W1(REAL a,REAL b ){
     return IP<REAL,8,-2,2>(b,P8I_coeffs)-IP<REAL,8,-2,2>(a,P8I_coeffs);    
 }
 
-REAL __attribute__((weak)) Wp(REAL x){
+FUNC_QUALIFIER Wp(REAL x){
     return P<REAL,7,-1,2>(x,P8d_agregate_coeffs);    
 }
 
-REAL __attribute__((weak)) I_Wp(REAL a,REAL b){
+FUNC_QUALIFIER I_Wp(REAL a,REAL b){
         return IP<REAL,7,-1,2>(b,P8_agregate_coeffs)-IP<REAL,7,-1,2>(a,P8_agregate_coeffs);
 }
 #endif
@@ -80,7 +88,7 @@ REAL __attribute__((weak)) I_Wp(REAL a,REAL b){
 
 extern const int __attribute__((weak)) interpolation_range=1;
 
-REAL __attribute__((weak)) W1(REAL x){
+FUNC_QUALIFIER W1(REAL x){
     const auto fx=fabs(x);
     if(fx >=1 ){
             return 0;
@@ -90,11 +98,11 @@ REAL __attribute__((weak)) W1(REAL x){
     }
 }
 
-REAL __attribute__((weak)) W(REAL x,REAL y, REAL z){
+FUNC_QUALIFIER W(REAL x,REAL y, REAL z){
     return W1(x)*W1(y)*W1(z);
 }
 
-REAL __attribute__((weak)) W1d(REAL x){
+FUNC_QUALIFIER W1d(REAL x){
     if(x <1 && x >0){
         return -1;
     }
@@ -107,7 +115,7 @@ REAL __attribute__((weak)) W1d(REAL x){
 
 }
 
-REAL __attribute__((weak)) IH_W1(REAL x){
+INT_FUNC_QUALIFIER IH_W1(REAL x){
     if(x > 1){
         return 1;
     }
@@ -119,11 +127,11 @@ REAL __attribute__((weak)) IH_W1(REAL x){
     }
 }
 
-REAL __attribute__((weak)) I_W1(REAL a,REAL b ){
+FUNC_QUALIFIER I_W1(REAL a,REAL b ){
     return IH_W1(b)-IH_W1(a); 
 }
 
-REAL __attribute__((weak)) Wp(REAL x){
+FUNC_QUALIFIER Wp(REAL x){
     if(x <1 && x >=0){
         return 1;
     }
@@ -132,7 +140,7 @@ REAL __attribute__((weak)) Wp(REAL x){
     }
 }
 
-REAL IH_wp(REAL x){
+INT_FUNC_QUALIFIER  IH_wp(REAL x){
     if(x < 0){
     return 0;
     }
@@ -144,7 +152,7 @@ REAL IH_wp(REAL x){
     }
 }
 
-REAL __attribute__((weak)) I_Wp(REAL a,REAL b){
+FUNC_QUALIFIER I_Wp(REAL a,REAL b){
     return IH_wp(b)-IH_wp(a);
 }
 #endif

--- a/src/interpolation/interpolation.cpp
+++ b/src/interpolation/interpolation.cpp
@@ -7,8 +7,8 @@
 
 #ifdef GPUBUILD
     #define ARRAY_QUALIFIER __device__ __const__ REAL
-    #define FUNC_QUALIFIER __device__ REAL __attribute__((weak)) 
-    #define INT_FUNC_QUALIFIER __device__ inline REAL  
+    #define FUNC_QUALIFIER  __host__ __device__ REAL __attribute__((weak)) 
+    #define INT_FUNC_QUALIFIER __host__ __device__ inline REAL  
 #else
     #define ARRAY_QUALIFIER const REAL
     #define FUNC_QUALIFIER REAL __attribute__((weak)) 

--- a/src/interpolation/interpolation.cpp
+++ b/src/interpolation/interpolation.cpp
@@ -7,11 +7,11 @@
 
 #ifdef GPUBUILD
     #define ARRAY_QUALIFIER __device__ __const__ REAL
-    #define FUNC_QUALIFIER  __host__ __device__ REAL __attribute__((weak)) 
+    #define FUNC_QUALIFIER  __host__ __device__ REAL  
     #define INT_FUNC_QUALIFIER __host__ __device__ inline REAL  
 #else
     #define ARRAY_QUALIFIER const REAL
-    #define FUNC_QUALIFIER REAL __attribute__((weak)) 
+    #define FUNC_QUALIFIER REAL  
     #define INT_FUNC_QUALIFIER inline REAL  
 #endif
 

--- a/src/interpolation/poly_util.hpp
+++ b/src/interpolation/poly_util.hpp
@@ -1,10 +1,9 @@
 #ifndef POLYUTIL
 #define POLYUTIL
 
-
-
-#include<iostream>
-
+#ifdef GPUBUILD
+    #define DEVICE_QUALIFIER __device__  
+#endif
 // Some quick utility functions 
 // To evaluate piecewise polynomials in a compact region
 // with integer limits and integer bins
@@ -15,8 +14,8 @@
 // top include directory
 
 
-    template <class T,int Poly_degree,int lower_limit>
-    inline T P_eval(T x,const T* coeffs){
+ template <class T,int Poly_degree,int lower_limit>
+   DEVICE_QUALIFIER   inline T P_eval(T x,const T* coeffs){
             int start_idx = ( floor(x)-lower_limit)*(Poly_degree+1);
             T sum =coeffs[start_idx];
             for(int i=1; i<(Poly_degree+1);i++){
@@ -25,8 +24,8 @@
             return sum;
         }
 
-    template <class T,int Poly_degree,int lower_limit,int upper_limit>
-    inline T P(T x,const T* coeffs){
+ template <class T,int Poly_degree,int lower_limit,int upper_limit>
+   DEVICE_QUALIFIER  inline T P(T x,const T* coeffs){
 
         if( x >= upper_limit ||  x <= lower_limit){
             return 0;
@@ -36,8 +35,8 @@
         }
         }
 
-    template <class T, int Poly_degree,int lower_limit, int upper_limit>
-        inline T IP(T q,const T* coeffs){
+  template <class T, int Poly_degree,int lower_limit, int upper_limit>
+   DEVICE_QUALIFIER   inline T IP(T q,const T* coeffs){
             if(q >= upper_limit){
                 return 1;
             }else if(q < lower_limit){

--- a/src/interpolation/poly_util.hpp
+++ b/src/interpolation/poly_util.hpp
@@ -2,7 +2,9 @@
 #define POLYUTIL
 
 #ifdef GPUBUILD
-    #define DEVICE_QUALIFIER __device__  
+    #define DEVICE_QUALIFIER __host__ __device__  
+#else
+    #define DEVICE_QUALIFIER
 #endif
 // Some quick utility functions 
 // To evaluate piecewise polynomials in a compact region


### PR DESCRIPTION
- [X] device qualifiers in function definitions.
- [x] set function headers in `strugepic_w.hpp`, best way to do this.
- [x] configure build system to pass the correct DEFS when building the GPU version
- [x] Check that GPU and CPU version gives same numerical results.
   - [X] Range 1 PWL
   - [x]  Range 2 Poly      