### PR TITLE
Path segmentation on GPU

### DIFF
--- a/include/strugepic_propagators.hpp
+++ b/include/strugepic_propagators.hpp
@@ -70,8 +70,8 @@ void G_Theta_E(const amrex::Geometry geom,CParticleContainer&P, amrex::MultiFab&
 }
 
 
-typedef bool (*SEG_BOUNDARY)(const amrex::Geometry,std::array<amrex::Real,3> &, std::array<int,2> &);
-typedef void (*PART_BOUNDARY)(CParticle &, std::array<amrex::Real,3> &);
+typedef bool (*SEG_BOUNDARY)(const amrex::Geometry,amrex::Real *, int *);
+typedef void (*PART_BOUNDARY)(CParticle &, amrex::Real * );
 
 // This is for one particle type
 // If there are several you need to do this again
@@ -144,11 +144,9 @@ void Theta(CParticles&particles, const amrex::Geometry geom,amrex::Array4<amrex:
                 idx++;
             }
         
-        std::array<amrex::Real,3> seg_points;
-        std::array<int,2> seg_idx;
-        
-         int num_segments=construct_segments<comp>(p.pos(comp),new_pos,seg_points,seg_idx);
-         //bool out_not_periodic=segment_reflect<comp,W_range>(geom,seg_points,seg_idx);
+         amrex::Real seg_points[3];
+         int seg_idx[2]; 
+         int num_segments=construct_segments(p.pos(comp),new_pos,seg_points,seg_idx);
          bool out_not_periodic=F_SEG(geom,seg_points,seg_idx);
 
         for(int seg=0;seg<num_segments;seg++){
@@ -213,9 +211,10 @@ void Theta(CParticles&particles, const amrex::Geometry geom,amrex::Array4<amrex:
                 F_PART(p,seg_points);                
                 //particle_reflect<comp>(p,seg_points);
             }
+
+        // .Redistribute should wrap the particles if periodic
             else{
             p.pos(comp)+=dt*p.rdata(2+comp);
-            shift_periodic<comp>(geom,p);
             }
         // B Vel update
         p.rdata( (comp +2 )% 3 +2   )+=B_coef*res_c1;

--- a/src/strugepic_util.cpp
+++ b/src/strugepic_util.cpp
@@ -19,6 +19,7 @@
 #include <fstream>
 #include "strugepic_w.hpp"
 #include "strugepic_propagators.hpp"
+#include <AMReX_GpuQualifiers.H>
 
 
 void set_uniform_field(amrex::MultiFab &A, std::array<double,3> vals){
@@ -150,6 +151,25 @@ for(amrex::MFIter mfi= P.MakeMFIter(0) ;mfi.isValid();++mfi){
     }
     P.Redistribute();
 
+}
+
+// Only two segments
+// system starts at (0,0) 
+// cell size is 1 
+AMREX_GPU_HOST_DEVICE inline int construct_segments(amrex::Real x_start ,amrex::Real x_end, amrex::Real *seg_points,int *seg_idx){
+    seg_idx[0]=floor(x_start);
+    seg_idx[1]=floor(x_end);
+    int diff=seg_idx[1]-seg_idx[0];
+    int ng=abs(diff)+1;
+    seg_points[0]=x_start;
+    if(ng==2){
+    seg_points[1]=seg_idx[0]+(diff+1)/2;
+    seg_points[2]=x_end;
+    }
+    else{
+    seg_points[1]=x_end; 
+    }
+    return ng; 
 }
 
 


### PR DESCRIPTION
`warning: calling a __host__ function from a __host__ __device__ function is not allowed`
is emmitted when compiling but seems to work?, if issues arise just drop the `__host__` qualifier
before reflect_segment.

Changes the interface to the segment function to use simple `c` arrays. 

Also removed manual periodic wrapping as `.Redistribute()` is called at every time step and already handles this. 